### PR TITLE
Prevent converting NUL characters in strings read by `licensecheck`

### DIFF
--- a/src/find_licenses.jl
+++ b/src/find_licenses.jl
@@ -30,7 +30,9 @@ function license_table(dir, names; validate_strings = true, validate_paths = tru
         path = joinpath(dir, lic)
         validate_paths && (isfile(path) || continue)
         text = read(path, String)
-        validate_strings && (isvalid(String, text) || continue)
+        # In licensecheck we're going to convert the string to a `Cstring` with
+        # `unsafe_convert`, so the string can't have any NUL character
+        validate_strings && ((isvalid(String, text) && !Base.containsnul(text)) || continue)
         lc = licensecheck(text)
         if lc.license_file_percent_covered > 0
             push!(table, (; license_filename=lic, lc...))


### PR DESCRIPTION
Ref https://github.com/giordano/AnalyzeRegistry.jl/issues/14.  

I don't have the time to add tests now, if you have a good idea how to do that,
please go ahead! (_Edit_: I have a couple of ideas for how to test this, but I'll have the time to do it only tomorrow night) 