### PR TITLE
Add capability to scan sub-directories to find_licenses()

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,11 @@ julia> find_license(pkgdir(LicenseCheck))
 julia> is_osi_approved(find_license(pkgdir(LicenseCheck)))
 true
 
+julia> cd(pkgdir(LicenseCheck))
+julia> find_licenses(".", scan_subdir= true)
+3-element Vector{@NamedTuple{license_filename::String, licenses_found::Vector{String}, license_file_percent_covered::Float64}}:
+ (license_filename = "./LICENSE", licenses_found = ["MIT"], license_file_percent_covered = 98.82352941176471)
+ (license_filename = "./test/runtests.jl", licenses_found = ["MIT", "Latex2e"], license_file_percent_covered = 34.130982367758186)
+ (license_filename = "./test/nul_string_dir/LICENSE", licenses_found = ["MIT"], license_file_percent_covered = 98.82352941176471)
+
 ```

--- a/src/find_licenses.jl
+++ b/src/find_licenses.jl
@@ -129,7 +129,7 @@ function find_licenses(dir; allow_brute=true, max_bytes=MAX_LICENSE_SIZE_IN_BYTE
     for dirdata in walkdir(dir)
         root= dirdata[1]
         files= dirdata[3]
-        files= [f for f in files if isfile(joinpath(root, f))]  # Remove anything that isn't an actual file, i.e. a broken symlink symlinks to directories
+        files= [f for f in files if isfile(joinpath(root, f))]  # Remove anything that isn't an actual file, i.e. a broken symlink or symlinks to directories
         if allow_brute && (length(files) < CUTOFF)
             licenses_found= find_licenses_by_bruteforce(root; files=files, max_bytes=max_bytes, preserve_path= preserve_path)
         else

--- a/src/find_licenses.jl
+++ b/src/find_licenses.jl
@@ -129,6 +129,7 @@ function find_licenses(dir; allow_brute=true, max_bytes=MAX_LICENSE_SIZE_IN_BYTE
     for dirdata in walkdir(dir)
         root= dirdata[1]
         files= dirdata[3]
+        files= [f for f in files if isfile(joinpath(root, f))]  # Remove anything that isn't an actual file, i.e. a broken symlink symlinks to directories
         if allow_brute && (length(files) < CUTOFF)
             licenses_found= find_licenses_by_bruteforce(root; files=files, max_bytes=max_bytes, preserve_path= preserve_path)
         else

--- a/src/find_licenses.jl
+++ b/src/find_licenses.jl
@@ -47,7 +47,7 @@ function license_table(dir, names; validate_strings=true, validate_paths=true, p
 end
 
 """
-    find_licenses_by_list_intersection(dir) -> $(LICENSE_TABLE_TYPE_STRING)
+    find_licenses_by_list_intersection(dir; preserve_path= false) -> $(LICENSE_TABLE_TYPE_STRING)
 
 Checks to see if any license name in `LicenseCheck.LICENSE_NAMES` exists
 in `dir`, and if so, calls [`licensecheck`](@ref) on it. Returns the results
@@ -57,6 +57,8 @@ of all existing licenses and their `licensecheck` values, sorted from highest
 Operates by filtering the results of `readdir`, which should be efficient
 for small and moderately sized directories. See [`find_licenses_by_list`](@ref)
 for an alternate approach for very large directories.
+
+The path to the license files is preserved in the returned table if `preserve_path= true`
 """
 function find_licenses_by_list_intersection(dir; files=readfiles(dir), preserve_path= false)
     names = filter!(lic -> lowercase(lic) ∈ LOWERCASE_LICENSE_NAMES, files)
@@ -81,10 +83,12 @@ with different cases.
 find_licenses_by_list(dir) = license_table(dir, LICENSE_NAMES)
 
 """
-    find_licenses_by_bruteforce(dir; max_bytes = LicenseCheck.MAX_LICENSE_SIZE_IN_BYTES) -> $(LICENSE_TABLE_TYPE_STRING)
+    find_licenses_by_bruteforce(dir; max_bytes = LicenseCheck.MAX_LICENSE_SIZE_IN_BYTES, preserve_path= false) -> $(LICENSE_TABLE_TYPE_STRING)
 
 Calls [`licensecheck`](@ref) on every plaintext file in `dir` whose size is less than `max_bytes`,
-returning the results as a table. The parameter `max_bytes` defaults to $(MAX_LICENSE_SIZE_IN_BYTES ÷ 1000) KiB.
+returning the results as a table. The keyword `max_bytes` defaults to $(MAX_LICENSE_SIZE_IN_BYTES ÷ 1000) KiB.
+
+The path to the license files is preserved in the returned table if `preserve_path= true`
 """
 function find_licenses_by_bruteforce(dir; max_bytes=MAX_LICENSE_SIZE_IN_BYTES,
                                      files=readfiles(dir), preserve_path= false)
@@ -95,10 +99,12 @@ end
 const CUTOFF = 100
 
 """
-    find_licenses(dir; allow_brute=true, max_bytes = MAX_LICENSE_SIZE_IN_BYTES) -> $(LICENSE_TABLE_TYPE_STRING)
+    find_licenses(dir; allow_brute=true, max_bytes = MAX_LICENSE_SIZE_IN_BYTES, scan_subdir= false) -> $(LICENSE_TABLE_TYPE_STRING)
 
 Compiles a table of possible licenses at the top-level of a directory `dir` with their path and the results of [`licensecheck`](@ref), sorted by `license_file_percent_covered`. Uses [`find_licenses_by_bruteforce`](@ref) for directories
 with size less than $CUTOFF and [`find_licenses_by_list_intersection`](@ref) for larger directories.
+
+Contents of subdirectories are included in the results if `scan_subdir= true`.  The path to the license files is preserved in the returned table when this option is used.
 
 Simply acts as an alias for [`find_licenses_by_list_intersection`](@ref) if `allow_brute=false`.
 
@@ -109,12 +115,17 @@ julia> find_licenses(".")
 1-element Vector{NamedTuple{(:license_filename, :licenses_found, :license_file_percent_covered), Tuple{String, Vector{String}, Float64}}}:
  (license_filename = "LICENSE", licenses_found = ["MIT"], license_file_percent_covered = 98.82352941176471)
 
+julia> find_licenses(".", scan_subdir= true)
+3-element Vector{@NamedTuple{license_filename::String, licenses_found::Vector{String}, license_file_percent_covered::Float64}}:
+ (license_filename = "./LICENSE", licenses_found = ["MIT"], license_file_percent_covered = 98.82352941176471)
+ (license_filename = "./test/runtests.jl", licenses_found = ["MIT", "Latex2e"], license_file_percent_covered = 37.27647867950481)
+ (license_filename = "./test/nul_string_dir/LICENSE", licenses_found = ["MIT"], license_file_percent_covered = 98.82352941176471)
 ```
 """
 function find_licenses(dir; allow_brute=true, max_bytes=MAX_LICENSE_SIZE_IN_BYTES, scan_subdir= false)
     preserve_path= true == scan_subdir ? true : false
 
-    licenses_list= Vector{NamedTuple{(:license_filename, :licenses_found, :license_file_percent_covered), Tuple{String, Vector{String}, Float64}}}[]
+    licenses_list= Vector{NamedTuple{(:license_filename, :licenses_found, :license_file_percent_covered), Tuple{String, Vector{String}, Float64}}}()
     for dirdata in walkdir(dir)
         root= dirdata[1]
         files= dirdata[3]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,6 +114,17 @@ dorian_gray = """
         @test fl ∈ results
     end
 
+    @testset "`find_licenses` in subdirectories" begin
+        fl= find_licenses("..", scan_subdir= true)
+        @test length(fl) == 3
+        lic1= filter(l -> l.license_filename== "../LICENSE", fl)[1]
+        @test lic1.licenses_found == ["MIT"]
+        lic2= filter(l -> l.license_filename== "../test/runtests.jl", fl)[1]
+        @test issetequal(lic2.licenses_found, ["MIT", "Latex2e"])
+        lic3= filter(l -> l.license_filename== "../test/nul_string_dir/LICENSE", fl)[1]
+        @test lic3.licenses_found== ["MIT"]
+    end
+
     @testset "AnalyzeRegistry#14" begin
         fl = find_license("nul_string_dir")
         @test fl.license_filename == "LICENSE"


### PR DESCRIPTION
I needed to add some functionality to `LicenseCheck` to allow my package `PkgToSoftwareBOM` to easily search a package's source code, not just for the overall license but for any other licenses that may be attached to particular files.  

A new keyword is added to find_licenses(), `scan_subdir`, that allows the function to search through all the sub-directories of the specified target directory.  

To support this capability, the keyword `preserve_path` was added to `license_table`, `find_licenses_by_list_intersection`, and `find_licenses_by_bruteforce`.

Tests have been added to demonstrate the new capability and documentation updated.

If this PR is accepted I would request that a new version be released soon so that I can use it with my package.