### PR TITLE
setup local build env for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.jl.mem
 /Manifest.toml
 /docs/build/
+build
+deps/build.log

--- a/deps/README.md
+++ b/deps/README.md
@@ -1,0 +1,7 @@
+# build
+
+This is setup for building a copy of licensecheck with our `main.go` for debugging https://github.com/ericphanson/LicenseCheck.jl/issues/11
+
+- `main.go`: copied from https://github.com/JuliaPackaging/Yggdrasil/blob/master/L/licensecheck/bundled/main.go
+- `build.jl`: modified from https://github.com/JuliaPackaging/Yggdrasil/blob/348003044a6e4f2150b2a8de8282ebf7739c6a0d/L/licensecheck/build_tarballs.jl
+    - `build_tarballs.jl` is part of the https://binarybuilder.org/ cross-compilation & artifact distribution system used by Julia. For this branch, we replace it with a local build to allow for faster iteration and debugging.

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,18 @@
+# https://github.com/JuliaPackaging/Yggdrasil/blob/348003044a6e4f2150b2a8de8282ebf7739c6a0d/L/licensecheck/build_tarballs.jl#L26C1-L29C92
+
+build_dir = joinpath(@__DIR__, "..", "build")
+rm(build_dir; recursive=true, force=true)
+mkpath(build_dir)
+run(`git -C $build_dir clone https://github.com/google/licensecheck`)
+licencecheck_dir = joinpath(build_dir, "licensecheck")
+run(`git -C $licencecheck_dir checkout 5aa300fd3333d0c6592148249397338023cafcce`)
+
+main = joinpath(@__DIR__, "main.go")
+libdir = joinpath(build_dir, "lib")
+dlext = "dylib"
+_run = cmd -> run(Cmd(cmd; dir=licencecheck_dir))
+_run(`mkdir clib`)
+_run(`cp $main clib/main.go`)
+_run(`mkdir -p $libdir`)
+path = "$libdir/licensecheck.$dlext"
+_run(addenv(`go build -buildmode=c-shared -o $path clib/main.go`, "CGO_ENABLED" => "1"))

--- a/deps/main.go
+++ b/deps/main.go
@@ -1,0 +1,27 @@
+package main
+
+import "C"
+import (
+	"github.com/google/licensecheck"
+
+	"unsafe"
+)
+
+//export License
+func License(msg *C.char) (**C.char, int, float64) {
+	bytes := []byte(C.GoString(msg))
+	cov := licensecheck.Scan(bytes)
+
+	// https://stackoverflow.com/a/41493208
+	cArray := C.malloc(C.size_t(len(cov.Match)) * C.size_t(unsafe.Sizeof(uintptr(0))))
+	// mimic https://github.com/docker/docker-credential-helpers/pull/61
+	a := (*[(1 << 29) - 1]*C.char)(cArray)
+
+	for idx, m := range cov.Match {
+		a[idx] = C.CString(m.ID)
+	}
+
+	return (**C.char)(cArray), len(cov.Match), cov.Percent
+}
+
+func main() {}

--- a/src/LicenseCheck.jl
+++ b/src/LicenseCheck.jl
@@ -10,6 +10,9 @@ export find_licenses_by_bruteforce, find_licenses_by_list,
 include("OSI_LICENSES.jl")
 include("find_licenses.jl")
 
+# lib_path = licensecheck_jll.licensecheck
+lib_path = joinpath(pkgdir(LicenseCheck), "build", "lib", "licensecheck.dylib")
+
 """
     licensecheck(text::String) -> @NamedTuple{licenses_found::Vector{String}, license_file_percent_covered::Float64}
 
@@ -31,8 +34,7 @@ julia> licensecheck(text)
 ```
 """
 function licensecheck(text::String)
-    arr, dims, license_file_percent_covered = ccall((:License,
-                                                     licensecheck_jll.licensecheck),
+    arr, dims, license_file_percent_covered = ccall((:License, lib_path),
                                                     Tuple{Ptr{Ptr{UInt8}},Cint,Float64},
                                                     (Cstring,), text)
     return (; licenses_found=unsafe_string.(unsafe_wrap(Array, arr, dims; own=true)),
@@ -48,7 +50,7 @@ Checks if a [SDPX 3.10 identifier](https://spdx.dev/ids/) is
 or if a `NamedTuple` with a `licenses_found` key contains only OSI-approved SDPX 3.10 identifiers.
 
 !!! warning
-    
+
     Note that [`licensecheck`](@ref) understands a larger number of licenses than
     SDPX 3.10, and can output results which are not SDPX 3.10 identifiers.
     Such licenses will yield `is_osi_approved(name) == false` regardless of

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,11 +115,12 @@ dorian_gray = """
     end
 
     @testset "AnalyzeRegistry#14" begin
-        fl = find_license("nul_string_dir")
+        nul_str_dir = joinpath(@__DIR__, "nul_string_dir")
+        fl = find_license(nul_str_dir)
         @test fl.license_filename == "LICENSE"
         @test fl.licenses_found == ["MIT"]
         @test fl.license_file_percent_covered > 90
-        @test_throws ArgumentError LicenseCheck.license_table("nul_string_dir",
+        @test_throws ArgumentError LicenseCheck.license_table(nul_str_dir,
                                                               ["file_with_nul_in_the_middle.txt"];
                                                               validate_strings=false)
     end


### PR DESCRIPTION
Steps to reproduce the issue:

```sh
git clone https://github.com/ericphanson/LicenseCheck.jl
cd LicenseCheck.jl
git checkout eph/local-build
```

Then start `julia` with the `--project=.` flag to activate the current directory:

```sh
julia --project=.
```

Then from the Julia REPL, press `]` to enter package management mode:

```julia
pkg> build
```

Press backspace to exit. Then run
```julia
cd("test") # enter test directory
using LicenseCheck
for i = 1:10000
     println(i); include("runtests.jl")
end
```

Or directly from a shell:

```sh
julia --project=. -e 'using Pkg; Pkg.build()'
julia --project=. -e 'for i=1:1000; println(i); include("test/runtests.jl"); end'
```
