### PR TITLE
build with c wrapper

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -8,11 +8,18 @@ licencecheck_dir = joinpath(build_dir, "licensecheck")
 run(`git -C $licencecheck_dir checkout 5aa300fd3333d0c6592148249397338023cafcce`)
 
 main = joinpath(@__DIR__, "main.go")
+wrapper_c = joinpath(@__DIR__, "wrapper.c")
 libdir = joinpath(build_dir, "lib")
 dlext = "dylib"
 _run = cmd -> run(Cmd(cmd; dir=licencecheck_dir))
 _run(`mkdir clib`)
 _run(`cp $main clib/main.go`)
 _run(`mkdir -p $libdir`)
-path = "$libdir/licensecheck.$dlext"
-_run(addenv(`go build -buildmode=c-shared -o $path clib/main.go`, "CGO_ENABLED" => "1"))
+
+# Build the Go library
+go_lib_path = "$libdir/licensecheck_go.$dlext"
+_run(addenv(`go build -buildmode=c-shared -o $go_lib_path clib/main.go`, "CGO_ENABLED" => "1"))
+
+# Build the C wrapper that manages signal handlers
+wrapper_lib_path = "$libdir/licensecheck.$dlext"
+run(`gcc -shared -fPIC -o $wrapper_lib_path $wrapper_c -ldl`)

--- a/deps/wrapper.c
+++ b/deps/wrapper.c
@@ -1,0 +1,157 @@
+/*
+ * C Wrapper for Go licensecheck library
+ *
+ * This wrapper saves and restores signal handlers around Go library initialization
+ * to prevent conflicts between Go's runtime and Julia's signal handling.
+ *
+ * The issue: Go's runtime installs signal handlers without SA_ONSTACK flag,
+ * which conflicts with Julia's expectations and causes crashes.
+ *
+ * The solution: Save Julia's signal handlers before loading Go, then restore them
+ * after Go initializes, allowing both runtimes to coexist.
+ */
+
+#include <dlfcn.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+// Go types from the generated header
+typedef signed char GoInt8;
+typedef unsigned char GoUint8;
+typedef short GoInt16;
+typedef unsigned short GoUint16;
+typedef int GoInt32;
+typedef unsigned int GoUint32;
+typedef long long GoInt64;
+typedef unsigned long long GoUint64;
+typedef GoInt64 GoInt;
+typedef GoUint64 GoUint;
+typedef size_t GoUintptr;
+typedef float GoFloat32;
+typedef double GoFloat64;
+
+// Return type for License function (from licensecheck_go.h)
+struct License_return {
+    char** r0;    // licenses array
+    GoInt r1;     // count
+    GoFloat64 r2; // percent
+};
+
+// The actual Go function signature
+typedef struct License_return (*LicenseFn)(char*);
+
+static void* go_handle = NULL;
+static LicenseFn go_license_fn = NULL;
+
+// Array to store original signal handlers
+#define NUM_SIGNALS 32
+static struct sigaction original_handlers[NUM_SIGNALS];
+static int saved_signals[] = {
+    SIGHUP, SIGINT, SIGQUIT, SIGILL, SIGTRAP, SIGABRT, SIGEMT, SIGFPE,
+    SIGBUS, SIGSEGV, SIGSYS, SIGPIPE, SIGALRM, SIGTERM, SIGURG, SIGSTOP,
+    SIGTSTP, SIGCONT, SIGCHLD, SIGTTIN, SIGTTOU, SIGIO, SIGXCPU, SIGXFSZ,
+    SIGVTALRM, SIGPROF, SIGWINCH, SIGINFO, SIGUSR1, SIGUSR2
+};
+static int num_saved_signals = sizeof(saved_signals) / sizeof(saved_signals[0]);
+
+/*
+ * Save all current signal handlers
+ */
+static int save_signal_handlers(void) {
+    for (int i = 0; i < num_saved_signals; i++) {
+        int sig = saved_signals[i];
+        if (sigaction(sig, NULL, &original_handlers[i]) < 0) {
+            // Some signals may not be valid on this system, continue
+            continue;
+        }
+    }
+    return 0;
+}
+
+/*
+ * Restore all saved signal handlers
+ */
+static int restore_signal_handlers(void) {
+    for (int i = 0; i < num_saved_signals; i++) {
+        int sig = saved_signals[i];
+        // Only restore if we successfully saved it
+        if (original_handlers[i].sa_handler != NULL ||
+            original_handlers[i].sa_sigaction != NULL) {
+            sigaction(sig, &original_handlers[i], NULL);
+        }
+    }
+    return 0;
+}
+
+/*
+ * Initialize the wrapper and load the Go library
+ * This should be called once before any License calls
+ */
+int wrapper_init(const char* lib_path) {
+    if (go_handle != NULL) {
+        // Already initialized
+        return 0;
+    }
+
+    // Save Julia's signal handlers
+    save_signal_handlers();
+
+    // Load the Go shared library
+    go_handle = dlopen(lib_path, RTLD_NOW | RTLD_LOCAL);
+    if (!go_handle) {
+        fprintf(stderr, "Failed to load Go library: %s\n", dlerror());
+        return -1;
+    }
+
+    // Small delay to let Go runtime initialize
+    // This ensures Go's signal handlers are installed
+    struct timespec ts = {0, 10000000}; // 10ms
+    nanosleep(&ts, NULL);
+
+    // Restore Julia's signal handlers, overwriting Go's handlers
+    restore_signal_handlers();
+
+    // Get the License function pointer
+    go_license_fn = (LicenseFn)dlsym(go_handle, "License");
+    if (!go_license_fn) {
+        fprintf(stderr, "Failed to find License symbol: %s\n", dlerror());
+        dlclose(go_handle);
+        go_handle = NULL;
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * Wrapper for the Go License function
+ * This is what Julia will actually call
+ * Returns the same struct as the Go function
+ */
+struct License_return License(char* text) {
+    struct License_return result = {NULL, 0, 0.0};
+
+    if (!go_license_fn) {
+        fprintf(stderr, "Error: wrapper not initialized. Call wrapper_init first.\n");
+        return result;
+    }
+
+    // Call the actual Go function
+    result = go_license_fn(text);
+    return result;
+}
+
+/*
+ * Cleanup function (optional)
+ */
+void wrapper_cleanup(void) {
+    if (go_handle) {
+        dlclose(go_handle);
+        go_handle = NULL;
+        go_license_fn = NULL;
+    }
+}


### PR DESCRIPTION
PR pointed to #13; if we actually wanted to do this, we would want to do it in Yggdrasil I think.

Instead of directly calling into the go-code and dlopening it ourself, we call into a C-wrapper that saves the signal handlers, loads the go lib, then restores the signal handlers. This solution was 100% Claude code. It does seem to work so I figured I'd put up the PR in case it is a useful data point.

Claude also noticed setting the ENV variable `GODEBUG=asyncpreemptoff=1` works (as long as its set before the go lib is loaded), as mentioned in https://github.com/golang/go/issues/75887#issue-3512082450. That doesn't seem like a great solution because it's global so it affects all loaded go code, not just the lib we are loading.