### PR TITLE
Add functions to manipulate active set of licenses.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1'
           - 'nightly'
         os:
@@ -42,9 +42,6 @@ jobs:
             arch: aarch64
           - os: ubuntu-latest
             arch: aarch64
-          - os: macOS-latest
-            arch: aarch64
-            version: '1.3'
     steps:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LicenseCheck"
 uuid = "726dbf0d-6eb6-41af-b36c-cd770e0f00cc"
 authors = ["Eric P. Hanson"]
-version = "0.3.0"
+version = "0.2.3"
 
 [deps]
 licensecheck_jll = "4ecb348a-8b88-51ea-b912-4c460483ee91"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "0.2.3"
 licensecheck_jll = "4ecb348a-8b88-51ea-b912-4c460483ee91"
 
 [compat]
-julia = "1.3"
+julia = "1.6"
 licensecheck_jll = "0.4"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,14 @@
 name = "LicenseCheck"
 uuid = "726dbf0d-6eb6-41af-b36c-cd770e0f00cc"
 authors = ["Eric P. Hanson"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 licensecheck_jll = "4ecb348a-8b88-51ea-b912-4c460483ee91"
 
 [compat]
 julia = "1.3"
+licensecheck_jll = "0.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/LicenseCheck.jl
+++ b/src/LicenseCheck.jl
@@ -37,8 +37,18 @@ function licensecheck(text::String)
             licensecheck_jll.licensecheck),
         Tuple{Ptr{Ptr{UInt8}},Cint,Float64},
         (Cstring,), text)
-    return (; licenses_found=unsafe_string.(unsafe_wrap(Array, arr, dims; own=true)),
-        license_file_percent_covered=license_file_percent_covered)
+
+    try
+        licenses_found = unsafe_string.(unsafe_wrap(Array, arr, dims; own=false))
+        return (; licenses_found, license_file_percent_covered)
+    finally
+        ccall((:FreeLicenseResult,
+                licensecheck_jll.licensecheck),
+            Nothing,
+            (Ptr{Ptr{UInt8}}, Cint),
+            arr, dims)
+
+    end
 end
 
 """

--- a/src/LicenseCheck.jl
+++ b/src/LicenseCheck.jl
@@ -17,7 +17,7 @@ include("find_licenses.jl")
 
 Returns a vector of the names of licenses matched in `text` and the percent of the text covered by these matches.
 
-The check is performed with active license set which can be controlled and default initialized with `reset_to_builtin_licenses`.
+The check is performed with active license set which can be modified with [`add_builtin_license`](@ref), [`add_license`](@ref), and [`clear_license_list`](@ref).  The defaults are initialized with [`reset_to_builtin_licenses`](@ref), which can be called to reset the (implicit) license set to the defaults.
 
 This provides some of the functionality of `licensecheck.Scan` in the original Go library ([https://github.com/google/licensecheck](https://github.com/google/licensecheck)).
 
@@ -136,7 +136,7 @@ end
 Adds new license to the active license set with provided `id` and `license_regular_expression`.
 
 Check documentation [https://pkg.go.dev/github.com/google/licensecheck#hdr-Scanning](https://pkg.go.dev/github.com/google/licensecheck#hdr-Scanning) to know how to create `license_regular_expression`.
-There is great number of examples in [https://github.com/google/licensecheck/tree/main/licenses](here).
+There are many examples [https://github.com/google/licensecheck/tree/main/licenses](here).
 """
 function add_license(id::String, lre::String)
     ccall((:AddLicense, licensecheck_jll.licensecheck),

--- a/src/LicenseCheck.jl
+++ b/src/LicenseCheck.jl
@@ -5,7 +5,9 @@ using licensecheck_jll: licensecheck_jll
 export licensecheck, is_osi_approved
 export find_licenses, find_license
 export find_licenses_by_bruteforce, find_licenses_by_list,
-       find_licenses_by_list_intersection
+    find_licenses_by_list_intersection
+
+export clear_license_list, reset_to_builtin_licenses, add_builtin_license, add_license
 
 include("OSI_LICENSES.jl")
 include("find_licenses.jl")
@@ -13,9 +15,9 @@ include("find_licenses.jl")
 """
     licensecheck(text::String) -> @NamedTuple{licenses_found::Vector{String}, license_file_percent_covered::Float64}
 
-Returns a vector of the names of licenses (more specifically, the SPDX 3.10 license identifiers) matched in `text` and the percent of the text covered by these matches.
+Returns a vector of the names of licenses matched in `text` and the percent of the text covered by these matches.
 
-The full list of license IDs is located at [https://github.com/google/licensecheck/blob/v0.3.1/licenses/README.md](https://github.com/google/licensecheck/blob/v0.3.1/licenses/README.md), and includes the SDPX 3.10 licenses, [https://github.com/spdx/license-list-data/tree/v3.10/text](https://github.com/spdx/license-list-data/tree/v3.10/text).
+The check is performed with active license set which can be controlled and default initialized with `reset_to_builtin_licenses`.
 
 This provides some of the functionality of `licensecheck.Scan` in the original Go library ([https://github.com/google/licensecheck](https://github.com/google/licensecheck)).
 
@@ -32,11 +34,11 @@ julia> licensecheck(text)
 """
 function licensecheck(text::String)
     arr, dims, license_file_percent_covered = ccall((:License,
-                                                     licensecheck_jll.licensecheck),
-                                                    Tuple{Ptr{Ptr{UInt8}},Cint,Float64},
-                                                    (Cstring,), text)
+            licensecheck_jll.licensecheck),
+        Tuple{Ptr{Ptr{UInt8}},Cint,Float64},
+        (Cstring,), text)
     return (; licenses_found=unsafe_string.(unsafe_wrap(Array, arr, dims; own=true)),
-            license_file_percent_covered=license_file_percent_covered)
+        license_file_percent_covered=license_file_percent_covered)
 end
 
 """
@@ -73,5 +75,64 @@ function is_osi_approved(nt::NamedTuple)
     return !isempty(nt.licenses_found) && all(is_osi_approved, nt.licenses_found)
 end
 is_osi_approved(::Nothing) = false # so that it can always be used with `find_license`
+
+"""
+    clear_license_list()
+
+Empties active license set.
+
+`licensecheck`` for such case will return empty result.
+
+See also: `add_builtin_license`, `add_license`
+"""
+function clear_license_list()
+    ccall((:ClearLicenseList, licensecheck_jll.licensecheck),
+        Nothing,
+        ())
+    return nothing
+end
+
+"""
+    reset_to_builtin_licenses()
+
+Reset active license set to the full state of built in licenses.
+
+The full list of license IDs is located at [https://github.com/google/licensecheck/blob/v0.3.1/licenses/README.md](https://github.com/google/licensecheck/blob/v0.3.1/licenses/README.md), and includes the SDPX 3.10 licenses, [https://github.com/spdx/license-list-data/tree/v3.10/text](https://github.com/spdx/license-list-data/tree/v3.10/text).
+"""
+function reset_to_builtin_licenses()
+    ccall((:ResetToBuiltinLicences, licensecheck_jll.licensecheck),
+        Nothing,
+        ())
+    return nothing
+end
+
+"""
+    add_builtin_license(name::String)
+
+Add one of the built in licenses to the active license set.
+See `reset_to_builtin_licenses` to learn which values `name` can take.
+Will have no effect or error if `name` is not found.
+"""
+function add_builtin_license(name::String)
+    ccall((:AddBuiltinLicense, licensecheck_jll.licensecheck),
+        Nothing,
+        (Cstring,), name)
+    return nothing
+end
+
+"""
+    add_license(id::String, license_regular_expression::String)
+
+Adds new license to the active license set with provided `id` and `license_regular_expression`.
+
+Check documentation [https://pkg.go.dev/github.com/google/licensecheck#hdr-Scanning](https://pkg.go.dev/github.com/google/licensecheck#hdr-Scanning) to know how to create `license_regular_expression`.
+There is great number of examples in [https://github.com/google/licensecheck/tree/main/licenses](here).
+"""
+function add_license(id::String, lre::String)
+    ccall((:AddLicense, licensecheck_jll.licensecheck),
+        Nothing,
+        (Cstring, Cstring), id, lre)
+    return nothing
+end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,17 @@ dorian_gray = """
     There is no such thing as a moral or an immoral book.  Books are well
     written, or badly written.  That is all."""
 
+
+lre = """
+The highest as the lowest form of __1__ is a 
+((mode of))??
+autobiography.
+Those who find ugly meanings in 
+((beautiful||ugly))
+things are corrupt without
+being charming.  This is a fault.
+"""
+
 @testset "LicenseCheck" begin
     @testset "`licensecheck`" begin
         result = licensecheck(MIT)
@@ -83,6 +94,22 @@ dorian_gray = """
         @test result.license_file_percent_covered ≈
               100 * (length(MIT) + length(Latex2e)) /
               (length(dorian_gray) + length(MIT) + length(Latex2e)) atol = 5
+
+        clear_license_list()
+        @test licensecheck(MIT).licenses_found == []
+
+        add_builtin_license("MIT")
+        @test licensecheck(MIT).licenses_found == ["MIT"]
+        @test licensecheck(Latex2e).licenses_found == []
+
+        @test licensecheck(dorian_gray).licenses_found == []
+        add_license("mylicense", lre)
+        @test licensecheck(dorian_gray).licenses_found == ["mylicense"]
+        @test licensecheck(Latex2e).licenses_found == []
+
+        reset_to_builtin_licenses()
+        @test licensecheck(MIT * "\n" * Latex2e).licenses_found == ["MIT", "Latex2e"]
+        @test licensecheck(dorian_gray).licenses_found == []
     end
 
     @testset "`is_osi_approved`" begin
@@ -104,7 +131,7 @@ dorian_gray = """
         @test fl.license_file_percent_covered > 90
 
         for method in (find_licenses, dir -> find_licenses(dir; allow_brute=false),
-             find_licenses_by_bruteforce, find_licenses_by_list_intersection)
+            find_licenses_by_bruteforce, find_licenses_by_list_intersection)
             results = method(joinpath(@__DIR__, ".."))
             @test only(results) == fl
         end
@@ -120,7 +147,7 @@ dorian_gray = """
         @test fl.licenses_found == ["MIT"]
         @test fl.license_file_percent_covered > 90
         @test_throws ArgumentError LicenseCheck.license_table("nul_string_dir",
-                                                              ["file_with_nul_in_the_middle.txt"];
-                                                              validate_strings=false)
+            ["file_with_nul_in_the_middle.txt"];
+            validate_strings=false)
     end
 end


### PR DESCRIPTION
Update code to work with 0.4 version of licensecheck_jll and add functions to manipulate active set of licenses.

This will only work together with version 0.4 of `licensecheck_jll`, proposed in https://github.com/JuliaPackaging/Yggdrasil/pull/12455